### PR TITLE
S3 mock for route tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev": "NODE_ENV=dev nodemon --watch 'src/**/*.ts' --exec 'ts-node' --files src/index.ts",
     "linter": "tslint -c tslint.json 'src/**/*.ts' -c test/tslint.json 'test/**/*.ts'",
     "test:unit": "mocha --require 'ts-node/register/transpile-only' test/unit/**/*.spec.ts",
-    "test:route": "NODE_ENV=test mocha --require 'ts-node/register/transpile-only' test/route/**/*.spec.ts",
-    "test:route-auth": "mocha --require 'ts-node/register/transpile-only' test/routeAuth/**/*.spec.ts",
+    "test:route": "NODE_ENV=test PORT=8182 mocha --require 'ts-node/register/transpile-only' test/route/**/*.spec.ts",
+    "test:route-auth": "PORT=8182 mocha --require 'ts-node/register/transpile-only' test/routeAuth/**/*.spec.ts",
     "test": "npm run test:unit && npm run test:route && npm run test:route-auth",
     "coverage": "nyc npm run test:unit",
     "mocks": "dyson mocks 8080"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import * as dotenv from 'dotenv';
 import IConfig from './interfaces/IConfig';
 import Environment from './utils/Environment';
 
-if (Environment.isNotProd(process.env.NODE_ENV)) {
+if (Environment.isDev(process.env.NODE_ENV)) {
   dotenv.config();
 }
 
@@ -32,12 +32,12 @@ const config: IConfig = {
       sslRequired: 'external'
     },
     s3: {
-      accessKeyId: process.env.AWS_ACCESS_KEY,
-      bucket: process.env.AWS_BUCKET,
-      region: process.env.AWS_REGION,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      accessKeyId: process.env.AWS_ACCESS_KEY || 'dummy-access-key',
+      bucket: process.env.AWS_BUCKET || 'dummy-bucket',
+      region: process.env.AWS_REGION || 'dummy-region',
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy-secret-access-key',
       serverSideEncryption: 'aws:kms',
-      sseKmsKeyId: process.env.SSE_KMS_KEY_ID
+      sseKmsKeyId: process.env.SSE_KMS_KEY_ID || 'dummy-sse-kms-key-id'
     },
     virusScan: {
       host: process.env.VIRUS_SCAN_HOST || 'localhost',

--- a/src/services/S3Service.ts
+++ b/src/services/S3Service.ts
@@ -20,7 +20,7 @@ class S3Service {
   }
 
   public init(config: IConfig): AWS.S3 {
-    const {s3}: any = config.services;
+    const {s3}: IConfig['services'] = config.services;
     return new AWS.S3({
       accessKeyId: s3.accessKeyId,
       region: s3.region,

--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -1,10 +1,14 @@
 class Environment {
-  public static isNotProd(nodeEnv?: string): boolean {
-    return ['dev', 'test'].includes(nodeEnv || 'prod');
+  public static isNotProd(nodeEnv: string = ''): boolean {
+    return ['dev', 'test'].includes(nodeEnv);
   }
 
-  public static isProd(nodeEnv?: string): boolean {
-    return !this.isNotProd(nodeEnv || 'prod');
+  public static isProd(nodeEnv: string = ''): boolean {
+    return ['prod', ''].includes(nodeEnv);
+  }
+
+  public static isDev(nodeEnv: string = ''): boolean {
+    return nodeEnv === 'dev';
   }
 }
 

--- a/src/validation/Validation.ts
+++ b/src/validation/Validation.ts
@@ -1,8 +1,9 @@
 import * as Joi from 'joi';
 
 class Validation {
-  public filenameRegex: RegExp = /^([a-f0-9]{4,}-){4}[a-f0-9]{4,}$/;
-  protected joi = Joi;
+  public filenamePattern: string = '([a-f0-9]{4,}-){4}[a-f0-9]{4,}';
+  public filenameRegex: RegExp = new RegExp(`^${this.filenamePattern}$`);
+  protected joi: any = Joi;
 }
 
 export default Validation;

--- a/test/route/src/routers/FilesRouter.spec.ts
+++ b/test/route/src/routers/FilesRouter.spec.ts
@@ -14,23 +14,13 @@ describe('FilesRouter', () => {
   beforeEach(() => {
     const pathRegex: RegExp = new RegExp(`/${validation.filenamePattern}`);
 
-    nock(`https://dummy-bucket.s3.dummy-region.amazonaws.com/test-process-key/${config.fileVersions.original}`)
+    Object.keys(config.fileVersions).forEach((fileVersion) => {
+      nock(`https://dummy-bucket.s3.dummy-region.amazonaws.com/test-process-key/${fileVersion}`)
       .put(pathRegex)
       .reply(200)
       .get(pathRegex)
       .reply(200, {}, {'Content-type': 'application/pdf'});
-
-    nock(`https://dummy-bucket.s3.dummy-region.amazonaws.com/test-process-key/${config.fileVersions.clean}`)
-      .put(pathRegex)
-      .reply(200)
-      .get(pathRegex)
-      .reply(200, {}, {'Content-type': 'application/pdf'});
-
-    nock(`https://dummy-bucket.s3.dummy-region.amazonaws.com/test-process-key/${config.fileVersions.ocr}`)
-      .put(pathRegex)
-      .reply(200)
-      .get(pathRegex)
-      .reply(200, {}, {'Content-type': 'application/pdf'});
+    });
 
     nock('https://dummy-bucket.s3.dummy-region.amazonaws.com')
       .post('/?delete')

--- a/test/unit/src/utils/Environment.spec.ts
+++ b/test/unit/src/utils/Environment.spec.ts
@@ -2,7 +2,7 @@ import Environment from '../../../../src/utils/Environment';
 import {expect} from '../../../setupTests';
 
 describe('Environment', () => {
-  describe('notProd()', () => {
+  describe('isNotProd()', () => {
     it('should return true when given a value of dev', (done) => {
       const isNotProd: boolean = Environment.isNotProd('dev');
       expect(isNotProd).to.be.true;
@@ -22,13 +22,13 @@ describe('Environment', () => {
     });
 
     it('should return false when not given a value', (done) => {
-      const isNotProd: boolean = Environment.isNotProd();
+      const isNotProd: boolean = Environment.isNotProd(undefined);
       expect(isNotProd).to.be.false;
       done();
     });
   });
 
-  describe('prod()', () => {
+  describe('isProd()', () => {
     it('should return false when given a value of dev', (done) => {
       const isProd: boolean = Environment.isProd('dev');
       expect(isProd).to.be.false;
@@ -48,8 +48,28 @@ describe('Environment', () => {
     });
 
     it('should return true when not given a value', (done) => {
-      const isProd: boolean = Environment.isProd();
+      const isProd: boolean = Environment.isProd(undefined);
       expect(isProd).to.be.true;
+      done();
+    });
+  });
+
+  describe('isDev()', () => {
+    it('should return true when given a value of dev', (done) => {
+      const isDev: boolean = Environment.isDev('dev');
+      expect(isDev).to.be.true;
+      done();
+    });
+
+    it('should return false when given a value other than dev', (done) => {
+      const isDev: boolean = Environment.isDev('test');
+      expect(isDev).to.be.false;
+      done();
+    });
+
+    it('should return false when not given a value', (done) => {
+      const isDev: boolean = Environment.isDev(undefined);
+      expect(isDev).to.be.false;
       done();
     });
   });


### PR DESCRIPTION
- Add S3 mocks for the route tests so we don't need S3 config for the tests and we're not hitting the actual S3 service.

- Run the route tests on a different port so they can be run at the same time as the app.